### PR TITLE
Update example to be valid for CICS

### DIFF
--- a/example/umthsmpl.tex
+++ b/example/umthsmpl.tex
@@ -127,8 +127,9 @@
 \fourthreader{Mary Lamb}   % Optional
 %\fifthreader{}            % Optional
 %\sixthreader{}            % Optional
-\departmentchair{Pete Shearer} % Uses "Department Chair" as the title. To
+\departmentchair[Chair of the Faculty]{Pete Shearer} % Default uses "Department Chair" as the title. To
 % use an alternate title, such as "Chair", use \departmentchair[Chair]{Pete Shearer}
+% CICS uses "Chair of the Faculty" as of 2019.
 \departmentname{Sheep Studies}
 
 %% If your degree is something other than a Ph.D. (for a dissertation), or


### PR DESCRIPTION
Update the example to use "Chair of the Faculty" so that the default signature page is correct for CICS dissertations.